### PR TITLE
cas登录后创建的用户密码默认为用户编号，账号后缀默认为e-u.cn || cas The user password created after cas login defaults to the user number, and the account suffix defaults to e-u.cn

### DIFF
--- a/client/shared/model/config.ts
+++ b/client/shared/model/config.ts
@@ -60,6 +60,11 @@ export interface GlobalConfig {
    */
   disableUserRegisterBtn?: boolean;
 
+  /**
+   * cas登出url
+   */
+  casLogoutUrl?: string;
+
   announcement?:
     | false
     | {

--- a/client/web/src/components/modals/SettingsView/Account.tsx
+++ b/client/web/src/components/modals/SettingsView/Account.tsx
@@ -25,6 +25,10 @@ import {
 import { EmailVerify } from '../EmailVerify';
 import { ModifyPassword } from '../ModifyPassword';
 import { isBuiltinEmail } from '@/utils/user-helper';
+import {
+  useGlobalConfigStore
+} from 'tailchat-shared';
+import axios from 'axios';
 
 export const SettingsAccount: React.FC = React.memo(() => {
   const userInfo = useUserInfo();
@@ -78,10 +82,19 @@ export const SettingsAccount: React.FC = React.memo(() => {
     const key = openModal(<ModifyPassword onSuccess={() => closeModal(key)} />);
   }, []);
 
+  const { casLogoutUrl } =
+    useGlobalConfigStore((state) => ({
+      casLogoutUrl: state.casLogoutUrl
+    }));
   // 登出
   const handleLogout = useCallback(async () => {
     await setUserJWT(null);
-
+    if(casLogoutUrl!=null && casLogoutUrl!=''){
+      const locationUrl = window.location.href;
+      // 登出cas
+      window.location.replace(casLogoutUrl+`?service=`+locationUrl);
+      return;
+    }
     window.location.replace('/'); // 重载页面以清空所有状态
   }, []);
 

--- a/docker-compose.env
+++ b/docker-compose.env
@@ -44,6 +44,8 @@ IAM_CAS_SECRET=a1b2c3d4
 IAM_CAS_URI_AUTHORIZE=https://cas.gds.mtn/oauth2.0/authorize
 IAM_CAS_URI_ACCESS_TOKEN=https://cas.gds.mtn/oauth2.0/accessToken
 IAM_CAS_URI_USERINFO=https://cas.gds.mtn/oauth2.0/profile
+#cas登出地址
+IAM_CAS_LOGOUT_URL=https://cas.gds.mtn/logout
 #iam登录后的账号邮箱后缀
 IAM_DOMAIN=e-u.cn
 

--- a/docker-compose.env
+++ b/docker-compose.env
@@ -44,6 +44,8 @@ IAM_CAS_SECRET=a1b2c3d4
 IAM_CAS_URI_AUTHORIZE=https://cas.gds.mtn/oauth2.0/authorize
 IAM_CAS_URI_ACCESS_TOKEN=https://cas.gds.mtn/oauth2.0/accessToken
 IAM_CAS_URI_USERINFO=https://cas.gds.mtn/oauth2.0/profile
+#iam登录后的账号邮箱后缀
+IAM_DOMAIN=e-u.cn
 
 #游客访问开关
 DISABLE_GUEST_LOGIN=true

--- a/server/packages/sdk/src/services/lib/settings.ts
+++ b/server/packages/sdk/src/services/lib/settings.ts
@@ -60,6 +60,7 @@ export const config = {
       process.env.DISABLE_USER_REGISTER_BTN
     ), // 是否禁用登录页面的用户注册按钮
   },
+  casLogoutUrl: process.env.IAM_CAS_LOGOUT_URL,
 };
 
 export const builtinAuthWhitelist = [

--- a/server/plugins/com.msgbyte.iam/services/iam.service.ts
+++ b/server/plugins/com.msgbyte.iam/services/iam.service.ts
@@ -87,7 +87,7 @@ class IAMService extends TcService {
         const username = providerUserInfo.username;
         const email =
           providerUserInfo.email ||
-          `${username}.${strategyName}@iam.msgbyte.com`;
+          `${username}.${strategyName}@` + (process.env.IAM_DOMAIN || `e-u.cn`);
 
         // 不存在记录，查找是否已经注册过，如果已经注册过需要绑定，如果没有注册过则创建账号并绑定用户关系
         const userInfo = await ctx.call('user.findUserByEmail', {

--- a/server/plugins/com.msgbyte.iam/services/iam.service.ts
+++ b/server/plugins/com.msgbyte.iam/services/iam.service.ts
@@ -122,7 +122,8 @@ class IAMService extends TcService {
           {
             email,
             nickname: providerUserInfo.nickname,
-            password: String(new db.Types.ObjectId()), // random password
+            // password: String(new db.Types.ObjectId()), // random password
+            password: providerUserInfo.username, //密码默认用户编号
             avatar,
             userType,
           }

--- a/server/services/core/config.service.ts
+++ b/server/services/core/config.service.ts
@@ -86,6 +86,7 @@ class ConfigService extends TcService {
       disableAddFriend: config.feature.disableAddFriend,
       disableOwnerLogin: config.feature.disableOwnerLogin,
       disableUserRegisterBtn: config.feature.disableUserRegisterBtn,
+      casLogoutUrl: config.casLogoutUrl,
       ...persistConfig,
     };
   }


### PR DESCRIPTION
undefined
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
null
