### PR TITLE
fix:将默认群组中的学员培养组改成学员班队组 || fix: Change the student training group in the default group to the student team group

### DIFF
--- a/client/web/src/components/modals/CreateGroup.tsx
+++ b/client/web/src/components/modals/CreateGroup.tsx
@@ -35,6 +35,15 @@ const panelTemplate: {
         parentId: '00',
         type: GroupPanelType.TEXT,
       },
+      {
+        id: '02',
+        name: t('markdown'),
+        parentId: '00',
+        type: GroupPanelType.PLUGIN,
+        provider: 'Markdown Panel',
+        pluginPanelName: 'Markdown Panel/customwebpanel',
+        meta: { disableSendMessage: false },
+      },
     ],
   },
   {
@@ -412,7 +421,7 @@ const panelTemplate: {
   },
   {
     key: 'student',
-    label: t('学员培养组'),
+    label: t('学员班队组'),
     panels: [
       {
         id: '00',


### PR DESCRIPTION
undefined
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
null
