### PR TITLE
fix: 将 "AI 服务" 插件引用的 ip 地址改为域名 || fix: Change the ip address referenced by the "AI Service" plugin to a domain name

### DIFF
--- a/client/web/plugins/cn.e-u.aiapplication/src/index.tsx
+++ b/client/web/plugins/cn.e-u.aiapplication/src/index.tsx
@@ -16,7 +16,7 @@ regCustomPanel({
   render: () => (
     <Webview
       className="w-full h-full bg-white"
-      url="http://192.168.200.87:8084/index.html#/app/list"
+      url="http://talks.hjqtxy.net:8084/index.html#/app/list"
     />
   ),
   useIsShow: useIconIsShow,


### PR DESCRIPTION
undefined

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
undefined
